### PR TITLE
finished the READ service(query with supplier_id)

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -95,6 +95,16 @@ class Supplier(object):
 
         if document.exists():
             self.id = document['_id']
+    
+    def update(self):
+        """ Updates a Supplier in the database """
+        try:
+            document = self.database[self.id]
+        except KeyError:
+            document = None
+        if document:
+            document.update(self.serialize())
+            document.save()
 
 
     def save(self):
@@ -165,6 +175,19 @@ class Supplier(object):
             supplier.id = doc['_id']
             results.append(supplier)
         return results
+    
+######################################################################
+#  F I N D E R   M E T H O D S
+######################################################################
+
+    @classmethod
+    def find(cls, supplier_id):
+        """ Query that finds Suppliers by their id """
+        try:
+            document = cls.database[supplier_id]
+            return Supplier().deserialize(document)
+        except KeyError:
+            return None
 
 
 ############################################################

--- a/service/service.py
+++ b/service/service.py
@@ -27,6 +27,22 @@ import service.error_handlers
 def hello():
     return "Hello Supplier!"
 
+######################################################################
+# RETRIEVE A SUPPLIER (READ)
+######################################################################
+@app.route('/suppliers/<supplier_id>', methods=['GET'])
+def get_suppliers(supplier_id):
+    """
+    Retrieve a single Supplier
+
+    This endpoint will return a Supplier based on it's id
+    """
+    app.logger.info("Request to Retrieve a supplier with id [%s]", supplier_id)
+    supplier = Supplier.find(supplier_id)
+    if not supplier:
+        raise NotFound("Supplier with id '{}' was not found.".format(supplier_id))
+    return make_response(jsonify(supplier.serialize()), status.HTTP_200_OK)
+
 
 ######################################################################
 # CREATE A NEW SUPPLIER
@@ -54,16 +70,19 @@ def create_suppliers():
         check_content_type('application/json')
         app.logger.info('Getting json data from API call')
         data = request.get_json()
+        # print("##########################")
+        # print(data)
     app.logger.info(data)
     supplier = Supplier()
     supplier.deserialize(data)
     supplier.save()
     app.logger.info('Supplier with new id [%s] saved!', supplier.id)
     message = supplier.serialize()
-    #location_url = url_for('get_suppliers', supplier_id=supplier.id, _external=True)
-    return make_response(jsonify(message), status.HTTP_201_CREATED)
+    # TODO after finishing Query and add utility functions
+    # location_url = url_for('get_suppliers', supplier_id=supplier.id, _external=True)
     # return make_response(jsonify(message), status.HTTP_201_CREATED,
-    #                      {'Location': location_url})
+    #                       {'Location': location_url})
+    return make_response(jsonify(message), status.HTTP_201_CREATED)
 
 
 

--- a/service/service.py
+++ b/service/service.py
@@ -59,7 +59,6 @@ def create_suppliers():
     if request.headers.get('Content-Type') == 'application/x-www-form-urlencoded':
         app.logger.info('Getting data from form submit')
         data = {
-            "id": request.form['id'],
             "name": request.form['name'],
             "like_count": request.form['like_count'],
             "is_active": request.form['is_active'],

--- a/service/service.py
+++ b/service/service.py
@@ -70,8 +70,6 @@ def create_suppliers():
         check_content_type('application/json')
         app.logger.info('Getting json data from API call')
         data = request.get_json()
-        # print("##########################")
-        # print(data)
     app.logger.info(data)
     supplier = Supplier()
     supplier.deserialize(data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -87,6 +87,21 @@ class TestModels(TestCase):
         self.assertEqual(suppliers[0].products, [1,2,3])
         self.assertEqual(suppliers[0].rating, 8.5)
 
+    def test_update_a_supplier(self):
+        """ Update a Supplier """
+        supplier = Supplier("supplier1", 2, True, [1,2,3], 8.5)
+        supplier.save()
+        self.assertNotEqual(supplier.id, None)
+        # Change it an save it
+        supplier.rating = 9.0
+        supplier.save()
+        # Fetch it back and make sure the id hasn't changed
+        # but the data did change
+        suppliers = Supplier.all()
+        self.assertEqual(len(suppliers), 1)
+        self.assertEqual(suppliers[0].rating, 9.0)
+        self.assertEqual(suppliers[0].name, "supplier1")
+
 
 
     def test_serialize_a_supplier(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,6 +150,28 @@ class TestModels(TestCase):
         """ Create a Suppleir with no name """
         supplier = Supplier(None, 2, True, [1,2,3], 8.5)
         self.assertRaises(DataValidationError, supplier.create)
+    
+    def test_find_supplier(self):
+        """ Find a Supplier by id """
+        Supplier("supplier1", 2, True, [1,2,3], 8.5).save()
+        # saved_supplier = Supplier("kitty", "cat").save()
+        saved_supplier = Supplier("supplier1", 2, True, [1,2,3], 8.5)
+        saved_supplier.save()
+        supplier = Supplier.find(saved_supplier.id)
+        self.assertIsNot(supplier, None)
+        self.assertEqual(supplier.id, saved_supplier.id)
+        self.assertEqual(supplier.name, "supplier1")
+    
+    def test_find_with_no_suppliers(self):
+        """ Find a Supplier with empty database """
+        supplier = Supplier.find("1")
+        self.assertIs(supplier, None)
+
+    def test_supplier_not_found(self):
+        """ Find a Supplier that doesnt exist """
+        Supplier("supplier1", 2, True, [1,2,3], 8.5).save()
+        supplier = Supplier.find("2")
+        self.assertIs(supplier, None)
 
     
     @patch('cloudant.database.CloudantDatabase.create_document')

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,6 +38,27 @@ class TestSupplierServer(TestCase):
         """ Test the index page """
         resp = self.app.get('/')
         self.assertEqual(resp.status_code, HTTP_200_OK)
+    
+
+    def test_get_supplier(self):
+        """ get a single Supplier """
+        test_supplier = {"id": 1, "name": "supplier1", "like_count": 2, "is_active": True, "products": [1,2,3], "rating": 8.5}
+        post_resp = self.app.post('/suppliers', json=test_supplier, content_type='application/json')
+        posted_data = post_resp.get_json()
+        resp = self.app.get(
+            "/suppliers/{}".format(posted_data['_id']), content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data['name'], "supplier1")
+    
+    def test_get_supplier_not_found(self):
+        """ Get a Supplier that doesn't exist """
+        resp = self.app.get('/suppliers/0')
+        self.assertEqual(resp.status_code, HTTP_404_NOT_FOUND)
+        data = resp.get_json()
+        logging.debug('data = %s', data)
+        self.assertIn('was not found', data['message'])
 
     def test_create_supplier(self):
         """ Create a new Supplier """
@@ -55,13 +76,19 @@ class TestSupplierServer(TestCase):
         # self.assertNotEqual(location, None)
         # Check the data is correct
         new_json = resp.get_json()
+        # print("#########after saved in the cloudant, the data becomes###############")
+        # print(new_json)
         self.assertEqual(new_json['name'], 'supplier1')
+        self.assertEqual(new_json['like_count'], 2)
+        self.assertEqual(new_json['products'], [1,2,3])
+        self.assertEqual(new_json['rating'], 8.5)
+        self.assertEqual(new_json['is_active'], True)
         # check that count has gone up and includes supplier1
-        # TODO
         # resp = self.app.get('/suppliers')
         # data = resp.get_json()
         # logging.debug('data = %s', data)
         # self.assertEqual(resp.status_code, HTTP_200_OK)
+        # TODO after finishing List Service
         # self.assertEqual(len(data), supplier_count + 1)
         # self.assertIn(new_json, data)
     

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -76,8 +76,6 @@ class TestSupplierServer(TestCase):
         # self.assertNotEqual(location, None)
         # Check the data is correct
         new_json = resp.get_json()
-        # print("#########after saved in the cloudant, the data becomes###############")
-        # print(new_json)
         self.assertEqual(new_json['name'], 'supplier1')
         self.assertEqual(new_json['like_count'], 2)
         self.assertEqual(new_json['products'], [1,2,3])


### PR DESCRIPTION
Finished the READ service (i.e get with a certain id)

Notice: if we follow the professor's BDD repo template and Cloudant database for storing objects, such unique "id" is labeled as "_id" which is a random string. I keep this accord with the professor's template, so the "id" is not as we supposed to do in the relational database, (if we change, we need to change every part from model definition to later CRUD services). We can discuss this issue in Tuesday's SCRUM.