### PR TITLE
Prevent nosetests to use suppliers API DB

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -36,6 +36,8 @@ authorizations = {
     }
 }
 
+# initialize DB without @app.before_first_request, to prevent nosetests using supplier DB
+Supplier.init_db("suppliers")
 
 ######################################################################
 # GET HOME PAGE
@@ -397,13 +399,6 @@ class SupplierRecommend(Resource):
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
-
-
-@app.before_first_request
-def init_db(dbname="suppliers"):
-    """ Initlaize the model """
-    Supplier.init_db(dbname)
-
 
 def data_reset():
     """ Removes all Suppliers from the database """

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,7 +9,8 @@ import unittest
 import logging
 from flask_api import status
 from werkzeug.datastructures import MultiDict, ImmutableMultiDict
-from service import service
+from service.service import initialize_logging, app
+from service.models import Supplier
 from .suppliers_factory import SupplierFactory
 
 # Status Codes
@@ -30,10 +31,10 @@ class TestService(unittest.TestCase):
 
 
     def setUp(self):
-        self.app = service.app.test_client()
-        service.initialize_logging(logging.INFO)
-        service.init_db("test")
-        service.data_reset()
+        self.app = app.test_client()
+        initialize_logging(logging.INFO)
+        Supplier.init_db("test")
+        Supplier.remove_all()
 
 
     def _create_suppliers(self, count):


### PR DESCRIPTION
1 Initialize API's DB without ```@app.before_first_request```, to prevent ```nosetests``` using API's DB
2 For now, whenever we run ```nosetests```, records of our app would not change, as it will use test DB